### PR TITLE
Fix category screen header

### DIFF
--- a/app/(app)/(tabs)/categorie.tsx
+++ b/app/(app)/(tabs)/categorie.tsx
@@ -1,4 +1,4 @@
-// app/(app)/(tabs)/index.tsx
+// app/(app)/(tabs)/categorie.tsx
 
 import { Category, List, fetchCategories, fetchLists } from '@/services/lists';
 import React, { useEffect, useState } from 'react';


### PR DESCRIPTION
## Summary
- correct header comment in app/(app)/(tabs)/categorie.tsx

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3d256c84832bab358cedace7b6e5