### PR TITLE
Define TopCategoryOfTheDay type

### DIFF
--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -3,12 +3,12 @@ import { ActivityIndicator, Image, StyleSheet, Text, View } from 'react-native'
 
 import CategoryCard from '@/components/CategoryCard'
 import { ThemedView } from '@/components/ui/ThemedView'
-import { fetchTopCategoryOfTheDay } from '@/services/categorie'
+import { fetchTopCategoryOfTheDay, TopCategoryOfTheDay } from '@/services/categorie'
 import { useRouter } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 
 export default function AccueilScreen() {
-  const [categoryOfTheDay, setCategoryOfTheDay] = useState<any>(null)
+  const [categoryOfTheDay, setCategoryOfTheDay] = useState<TopCategoryOfTheDay | null>(null)
   const [loading, setLoading] = useState(true)
   const { t } = useTranslation()
   const logo = require('../../../assets/images/logo.png')

--- a/services/categorie.ts
+++ b/services/categorie.ts
@@ -1,8 +1,13 @@
 import api from './api'
 import { Category } from './lists'
 
-export async function fetchTopCategoryOfTheDay(): Promise<Category> {
-  const { data } = await api.get<Category>('/categories/top-of-the-day') 
+export interface TopCategoryOfTheDay {
+  category: Category
+  hasFilled: boolean
+}
+
+export async function fetchTopCategoryOfTheDay(): Promise<TopCategoryOfTheDay> {
+  const { data } = await api.get<TopCategoryOfTheDay>('/categories/top-of-the-day')
   console.log('fetchTopCategoryOfTheDay', data)
   return data
 }


### PR DESCRIPTION
## Summary
- define `TopCategoryOfTheDay` interface in `services/categorie.ts`
- return the new type from `fetchTopCategoryOfTheDay`
- use the interface in the home tab

## Testing
- `npx expo lint` *(fails: Need to install the following packages: expo@53.0.9)*

------
https://chatgpt.com/codex/tasks/task_e_683f3cfd3108832b82cc15ee40d7b768