### PR TITLE
Refactor interfaces into dedicated files

### DIFF
--- a/app/(app)/(tabs)/categorie.tsx
+++ b/app/(app)/(tabs)/categorie.tsx
@@ -1,6 +1,7 @@
 // app/(app)/(tabs)/categorie.tsx
 
-import { Category, List, fetchCategories, fetchLists } from '@/services/lists';
+import { fetchCategories, fetchLists } from '@/services/lists';
+import type { Category, List } from '@/interfaces/services/lists';
 import React, { useEffect, useState } from 'react';
 import {
   ActivityIndicator,

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -12,13 +12,10 @@ import { ThemedView } from '@/components/ui/ThemedView';
 import { AuthContext } from '@/context/AuthContext';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useRouter } from 'expo-router';
+import type { LoginFormData } from '@/interfaces/forms/LoginFormData';
 
 const logo = require('../../assets/images/logo.png');
 
-interface FormData {
-  email: string;
-  password: string;
-}
 
 const schema = yup
   .object({
@@ -32,7 +29,7 @@ export default function LoginScreen() {
     control,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormData>({ resolver: yupResolver(schema) });
+  } = useForm<LoginFormData>({ resolver: yupResolver(schema) });
   const { user, signIn, loading, error } = useContext(AuthContext);
   const [busy, setBusy] = useState(false);
   const router = useRouter();
@@ -44,7 +41,7 @@ export default function LoginScreen() {
     }
   }, [user]);
 
-  const onSubmit = async (data: FormData) => {
+  const onSubmit = async (data: LoginFormData) => {
     setBusy(true);
     try {
       await signIn(data.email, data.password);

--- a/app/(auth)/register.tsx
+++ b/app/(auth)/register.tsx
@@ -13,14 +13,10 @@ import { ThemedView } from '@/components/ui/ThemedView'
 import { AuthContext } from '@/context/AuthContext'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useRouter } from 'expo-router'
+import type { RegisterFormData } from '@/interfaces/forms/RegisterFormData'
 
 const logo = require('../../assets/images/logo.png')
 
-interface FormData {
-  email:    string
-  username: string
-  password: string
-}
 
 const schema = yup
   .object({
@@ -35,12 +31,12 @@ export default function RegisterScreen() {
     control,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormData>({ resolver: yupResolver(schema) })
+  } = useForm<RegisterFormData>({ resolver: yupResolver(schema) })
   const { signUp, loading, error } = useContext(AuthContext)
   const [busy, setBusy] = useState(false)
   const router = useRouter()
 
-  const onSubmit = async (data: FormData) => {
+  const onSubmit = async (data: RegisterFormData) => {
     setBusy(true)
     try {
       await signUp(data.email, data.username, data.password)

--- a/components/CategoryCard.tsx
+++ b/components/CategoryCard.tsx
@@ -4,21 +4,11 @@ import { Image, Platform, StyleSheet, Text, TouchableOpacity } from 'react-nativ
 
 import { getImageUri } from '@/utils/getImageUri';
 import React from 'react';
+import type { CategoryCardProps } from '@/interfaces/components/CategoryCardProps';
 
 // import { getImageUri } from '../utils/getImageUri'; // <-- import
 
-interface Props {
-  name: string;
-  imageUrl: string;
-  onPress: () => void;
-  hasList?: boolean;
-  width?: number;
-  minHeight?: number;
-  iconSize?: number;
-  fontSize?: number;
-}
-
-export default function CategoryCard({ name, imageUrl, onPress, hasList, width, minHeight, iconSize = 64, fontSize = 16 }: Props) {
+export default function CategoryCard({ name, imageUrl, onPress, hasList, width, minHeight, iconSize = 64, fontSize = 16 }: CategoryCardProps) {
   return (
     <TouchableOpacity
       style={[

--- a/components/CategoryGrid.tsx
+++ b/components/CategoryGrid.tsx
@@ -1,18 +1,12 @@
-import { Category, List } from '@/services/lists'
+import type { Category, List } from '@/interfaces/services/lists'
 import { StyleSheet, View } from 'react-native'
 
 import { useRouter } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import CategoryCard from './CategoryCard'
+import type { CategoryGridProps } from '@/interfaces/components/CategoryGridProps'
 
-interface Props {
-  categories: Category[]
-  lists: List[]
-  search?: string
-  onCategoryPress?: (cat: Category) => void
-}
-
-export default function CategoryGrid({ categories, lists, search = '', onCategoryPress }: Props) {
+export default function CategoryGrid({ categories, lists, search = '', onCategoryPress }: CategoryGridProps) {
   const router = useRouter()
   const { t } = useTranslation()
 

--- a/components/SearchInput.tsx
+++ b/components/SearchInput.tsx
@@ -1,16 +1,10 @@
-import { StyleSheet, TextInput, TextInputProps, View } from 'react-native';
+import { StyleSheet, TextInput, View } from 'react-native';
 
 import { Ionicons } from '@expo/vector-icons';
 import React from 'react';
+import type { SearchInputProps } from '@/interfaces/components/SearchInputProps';
 
 // Utilisation d'une icône vectorielle (expo ou react-native-vector-icons)
-
-
-interface SearchInputProps extends TextInputProps {
-  value: string;
-  onChangeText: (text: string) => void;
-  style?: any;
-}
 
 export default function SearchInput({ value, onChangeText, style, ...props }: SearchInputProps) {
   return (

--- a/components/ui/Snackbar.tsx
+++ b/components/ui/Snackbar.tsx
@@ -6,10 +6,8 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
-  ViewStyle,
 } from 'react-native';
-
-type Variant = 'info' | 'success' | 'warning' | 'error';
+import type { SnackbarProps, Variant } from '@/interfaces/components/SnackbarProps';
 
 const COLORS: Record<Variant, string> = {
   info:    '#3B82F6', // bleu
@@ -18,13 +16,6 @@ const COLORS: Record<Variant, string> = {
   error:   '#EF4444', // rouge
 };
 
-interface SnackbarProps {
-  message: string;
-  variant?: Variant;
-  duration?: number;   // en ms
-  onDismiss?: () => void;
-  style?: ViewStyle;
-}
 
 export function Snackbar({
   message,

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -17,16 +17,7 @@ import { AccessToken, LoginManager } from 'react-native-fbsdk-next';
 
 import api from '@/services/api';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-
-interface AuthContextData {
-  user: AuthResponse['user'] | null;
-  loading: boolean;
-  error: string | null;
-  signIn: (email: string, password: string) => Promise<void>;
-  signUp: (email: string, username: string, password: string) => Promise<void>;
-  signOut: () => Promise<void>;
-  signInWithFacebook: (token: string) => Promise<void>;
-}
+import type { AuthContextData } from '@/interfaces/context/AuthContextData';
 
 export const AuthContext = createContext<AuthContextData>({
   user: null,

--- a/interfaces/components/CategoryCardProps.ts
+++ b/interfaces/components/CategoryCardProps.ts
@@ -1,0 +1,10 @@
+export interface CategoryCardProps {
+  name: string;
+  imageUrl: string;
+  onPress: () => void;
+  hasList?: boolean;
+  width?: number;
+  minHeight?: number;
+  iconSize?: number;
+  fontSize?: number;
+}

--- a/interfaces/components/CategoryGridProps.ts
+++ b/interfaces/components/CategoryGridProps.ts
@@ -1,0 +1,8 @@
+import type { Category, List } from '@/interfaces/services/lists';
+
+export interface CategoryGridProps {
+  categories: Category[];
+  lists: List[];
+  search?: string;
+  onCategoryPress?: (cat: Category) => void;
+}

--- a/interfaces/components/SearchInputProps.ts
+++ b/interfaces/components/SearchInputProps.ts
@@ -1,0 +1,7 @@
+import type { TextInputProps } from 'react-native';
+
+export interface SearchInputProps extends TextInputProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  style?: any;
+}

--- a/interfaces/components/SnackbarProps.ts
+++ b/interfaces/components/SnackbarProps.ts
@@ -1,0 +1,11 @@
+import type { ViewStyle } from 'react-native';
+
+export type Variant = 'info' | 'success' | 'warning' | 'error';
+
+export interface SnackbarProps {
+  message: string;
+  variant?: Variant;
+  duration?: number;
+  onDismiss?: () => void;
+  style?: ViewStyle;
+}

--- a/interfaces/context/AuthContextData.ts
+++ b/interfaces/context/AuthContextData.ts
@@ -1,0 +1,11 @@
+import type { AuthResponse } from '@/interfaces/services/auth';
+
+export interface AuthContextData {
+  user: AuthResponse['user'] | null;
+  loading: boolean;
+  error: string | null;
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, username: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  signInWithFacebook: (token: string) => Promise<void>;
+}

--- a/interfaces/forms/LoginFormData.ts
+++ b/interfaces/forms/LoginFormData.ts
@@ -1,0 +1,4 @@
+export interface LoginFormData {
+  email: string;
+  password: string;
+}

--- a/interfaces/forms/RegisterFormData.ts
+++ b/interfaces/forms/RegisterFormData.ts
@@ -1,0 +1,5 @@
+export interface RegisterFormData {
+  email: string;
+  username: string;
+  password: string;
+}

--- a/interfaces/services/auth.ts
+++ b/interfaces/services/auth.ts
@@ -1,0 +1,15 @@
+export interface LoginDto    { email: string; password: string }
+export interface RegisterDto { email: string; username: string; password: string }
+export interface FacebookLoginDto { accessToken: string }
+
+export interface AuthResponse {
+  access_token: string;
+  user: { id: string; email: string; username: string; avatarUrl?: string };
+}
+
+export interface MeResponse {
+  id: string;
+  email: string;
+  username: string;
+  avatarUrl?: string;
+}

--- a/interfaces/services/categorie.ts
+++ b/interfaces/services/categorie.ts
@@ -1,0 +1,6 @@
+import type { Category } from './lists';
+
+export interface TopCategoryOfTheDay {
+  category: Category;
+  hasFilled: boolean;
+}

--- a/interfaces/services/friendship.ts
+++ b/interfaces/services/friendship.ts
@@ -1,0 +1,7 @@
+export interface Friendship {
+  id: string;
+  requester: any;
+  addressee: any;
+  status: 'pending' | 'accepted' | 'rejected';
+  createdAt: string;
+}

--- a/interfaces/services/lists.ts
+++ b/interfaces/services/lists.ts
@@ -1,0 +1,21 @@
+export interface Category {
+  id: string;
+  name: string;
+  imageUrl?: string;
+}
+
+export interface Item {
+  id: string;
+  name: string;
+  rank: number;
+  imageUrl?: string;
+}
+
+export interface List {
+  id: string;
+  title: string;
+  category: Category;
+  items: Item[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/interfaces/services/stats.ts
+++ b/interfaces/services/stats.ts
@@ -1,0 +1,16 @@
+export interface CategoryStat {
+  id: string;
+  categoryId?: string;
+  name: string;
+  imageUrl?: string;
+  count: number; // nombre de listes remplies par l'utilisateur
+}
+
+export interface ItemStat {
+  id: string;
+  categoryId: string;
+  item: string;
+  score: number;
+  appearances: number;
+  updatedAt: string;
+}

--- a/interfaces/services/users.ts
+++ b/interfaces/services/users.ts
@@ -1,0 +1,11 @@
+export interface UserSummary {
+  id: string;
+  username: string;
+  email: string;
+  avatarUrl?: string;
+}
+
+export interface SearchUsersResult {
+  users: UserSummary[];
+  total: number;
+}

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -3,22 +3,13 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AxiosError } from 'axios';
 import api from './api';
-
-export interface LoginDto    { email: string; password: string }
-export interface RegisterDto { email: string; username: string; password: string }
-export interface FacebookLoginDto { accessToken: string }
-
-export interface AuthResponse {
-  access_token: string;
-  user: { id: string; email: string; username: string; avatarUrl?: string }
-}
-
-export interface MeResponse {
-  id: string;
-  email: string;
-  username: string;
-  avatarUrl?: string;
-}
+import type {
+  AuthResponse,
+  FacebookLoginDto,
+  LoginDto,
+  MeResponse,
+  RegisterDto,
+} from '@/interfaces/services/auth';
 
 /**
  * Authentification : retourne token + user

--- a/services/categorie.ts
+++ b/services/categorie.ts
@@ -1,10 +1,6 @@
 import api from './api'
-import { Category } from './lists'
-
-export interface TopCategoryOfTheDay {
-  category: Category
-  hasFilled: boolean
-}
+import type { Category } from '@/interfaces/services/lists'
+import type { TopCategoryOfTheDay } from '@/interfaces/services/categorie'
 
 export async function fetchTopCategoryOfTheDay(): Promise<TopCategoryOfTheDay> {
   const { data } = await api.get<TopCategoryOfTheDay>('/categories/top-of-the-day')

--- a/services/friendship.ts
+++ b/services/friendship.ts
@@ -1,14 +1,7 @@
 // src/services/friendship.ts
 
 import api from './api'
-
-export interface Friendship {
-  id: string
-  requester: any
-  addressee: any
-  status: 'pending' | 'accepted' | 'rejected'
-  createdAt: string
-}
+import type { Friendship } from '@/interfaces/services/friendship'
 
 // Envoyer une demande d'ami
 export async function sendFriendRequest(userId: string) {

--- a/services/lists.ts
+++ b/services/lists.ts
@@ -1,29 +1,8 @@
 // src/services/lists.ts
 
 import { DEVICE_LANG } from '../utils/locale';
-import api from "./api";
-
-export interface Category {
-  id: string;
-  name: string;
-  imageUrl?: string;
-}
-
-export interface Item {
-  id: string;
-  name: string;
-  rank: number;
-  imageUrl?: string;
-}
-
-export interface List {
-  id: string;
-  title: string;
-  category: Category;
-  items: Item[];
-  createdAt: string;
-  updatedAt: string;
-}
+import api from './api';
+import type { Category, Item, List } from '@/interfaces/services/lists';
 
 // Categories
 export async function fetchCategories(): Promise<Category[]> {

--- a/services/stats.ts
+++ b/services/stats.ts
@@ -1,21 +1,5 @@
 import api from './api'
-
-export interface CategoryStat {
-  id: string
-  categoryId?: string
-  name: string
-  imageUrl?: string
-  count: number // nombre de listes remplies par l'utilisateur
-}
-
-export interface ItemStat {
-  id: string
-  categoryId: string
-  item: string
-  score: number
-  appearances: number
-  updatedAt: string
-}
+import type { CategoryStat, ItemStat } from '@/interfaces/services/stats'
 
 export async function fetchCategoryStats(): Promise<CategoryStat[]> {
   const { data } = await api.get<CategoryStat[]>('/stats/categories')

--- a/services/users.ts
+++ b/services/users.ts
@@ -1,18 +1,7 @@
 // src/services/users.ts
 
 import api from './api';
-
-export interface UserSummary {
-  id: string;
-  username: string;
-  email: string;
-  avatarUrl?: string;
-}
-
-export interface SearchUsersResult {
-  users: UserSummary[];
-  total: number;
-}
+import type { SearchUsersResult, UserSummary } from '@/interfaces/services/users';
 
 /**
  * Recherche d'utilisateurs (pagination simple).


### PR DESCRIPTION
## Summary
- centralize service response and DTO interfaces under `interfaces/`
- add component, form and context interfaces
- update imports across services and components

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f3f3b8938832bab6c94ed676cbaab